### PR TITLE
Removed the 'app' attribute in the configuration of 'grunt-open' 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,8 +63,7 @@ var mozjpeg = require('imagemin-mozjpeg');
 
     open: {
       index: {
-        path: './index.html',
-        app: 'chrome'
+        path: './index.html'
       }
     },
 


### PR DESCRIPTION
Omitting the 'app' attribute uses the default browser that is installed on the system.
